### PR TITLE
Feature/refactor v 1 be

### DIFF
--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -36,17 +36,11 @@ const userSchema = new mongoose.Schema(
 );
 
 // Hash password before saving
-userSchema.pre('save', async function (next) {
-  if (!this.isModified('password')) return next();
+userSchema.pre('save', async function () {
+  if (!this.isModified('password')) return;
 
-  try {
-    const salt = await bcrypt.genSalt(10);
-    this.password = await bcrypt.hash(this.password, salt);
-    next();
-  } catch (err) {
-    console.error('Error hashing password:', err);
-    next(err);
-  }
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
 });
 
 // Method to compare passwords

--- a/frontend/src/components/reg-auth/LoginForm.jsx
+++ b/frontend/src/components/reg-auth/LoginForm.jsx
@@ -98,11 +98,13 @@ function LoginForm() {
             {loading ? 'Signing In...' : 'Sign In'}
           </SpaceBtn>
 
-          <Link to='/'>
-            <Button className='block w-full text-center' disabled={loading}>
-              Return to Home
-            </Button>
-          </Link>
+          <Button
+            href='/'
+            className='block w-full text-center'
+            disabled={loading}
+          >
+            Return to Home
+          </Button>
         </div>
 
         <p className='mt-4 text-center text-text-muted text-sm'>


### PR DESCRIPTION
- remove next entirely for async middleware:

Edited
`userModel.js`

What Was Actually Wrong
- trust proxy - Fixed in app.js (for rate limiter on Render)
- next() in async middleware - Just removed from userModel.js:39-44
- The Final Solution (from your own document):
- In Mongoose 9.x with async functions:

Don't use next parameter
Don't call next()
Just return to exit early
Let errors throw naturally (async auto-catches them)

Let's see!
